### PR TITLE
Using merge to upsert schools

### DIFF
--- a/dbSetup/models/tables/__init__.py
+++ b/dbSetup/models/tables/__init__.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     Integer,
     SmallInteger,
     String,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, relationship
 
@@ -209,7 +210,7 @@ class Pitching(Base):
     p_G = Column(SmallInteger, nullable=True)
     p_GS = Column(SmallInteger, nullable=True)
     p_CG = Column(SmallInteger, nullable=True)
-    p_SHO =Column(SmallInteger, nullable=True)
+    p_SHO = Column(SmallInteger, nullable=True)
     p_SV = Column(SmallInteger, nullable=True)
     p_IPouts = Column(Integer, nullable=True)
     p_H = Column(SmallInteger, nullable=True)
@@ -229,6 +230,7 @@ class Pitching(Base):
     p_SH = Column(SmallInteger, nullable=True)
     p_SF = Column(SmallInteger, nullable=True)
     p_GIDP = Column(SmallInteger, nullable=True)
+
 
 class Appearances(Base):
     __tablename__ = "appearances"
@@ -253,6 +255,7 @@ class Appearances(Base):
     G_dh = Column(SmallInteger, nullable=True)
     G_ph = Column(SmallInteger, nullable=True)
     G_pr = Column(SmallInteger, nullable=True)
+
 
 class Fielding(Base):
     __tablename__ = "fielding"


### PR DESCRIPTION
This pull request includes changes to the `dbSetup` module, focusing on database schema updates and improvements to the CSV processing service. The most important changes include adding a unique constraint to the SQLAlchemy models, removing the count of new rows in the CSV processing function, and refactoring the upsert logic for school records.

Database schema updates:

* [`dbSetup/models/tables/__init__.py`]: Added `UniqueConstraint` to the list of imported SQLAlchemy classes.
* [`dbSetup/models/tables/__init__.py`]: Added blank lines to improve readability between class definitions.

CSV processing service improvements:

* [`dbSetup/services/schools_csv_service.py`]: Removed the count of new rows from the `counts` dictionary in the `update_schools_from_csv` function.
* [`dbSetup/services/schools_csv_service.py`]: Added a comment to clarify the attribute extraction in the `process_row` function.
* [`dbSetup/services/schools_csv_service.py`]: Refactored the `process_row` function to use `session.merge` for upserting rows, simplifying the logic and ensuring the `updated_rows` count is incremented correctly.