### PR TITLE
playing time for pitchers added

### DIFF
--- a/dbSetup/models/views/__init__.py
+++ b/dbSetup/models/views/__init__.py
@@ -72,10 +72,7 @@ class PitchingStatsView(Base):
     p_HR_div9 = Column(Float, nullable = True) # HR per 9 innings
     p_BABIP = Column(Float, nullable = True) # Batting Average on Balls In Play
     p_LOB_percent = Column(Float, nullable = True) # Left On Base Percentage
-    #p_GB_percent= Column(Float, nullable = True) # Ground Ball Percentage
-    #p_HR_div_FB = Column(Float, nullable = True) # HR per Fly Ball
     p_FIP = Column(Float, nullable = True) # Fielding Independent Pitching
-    #p_XFIP = Column(Float, nullable = True) # Expected Fielding Independent Pitching
-    #p_WAR = Column(Float, nullable = True) # Wins Above Replacement
+    playing_time = Column(Float, nullable = True) # Playing Time
 
     # __table_args__ and relationships not needed because this is a view

--- a/dbSetup/services/create_pitchingstats_view.py
+++ b/dbSetup/services/create_pitchingstats_view.py
@@ -127,7 +127,14 @@ def create_pitchingstats_view():
             )
             +
             w.cFIP
-        , 2) AS p_FIP
+        , 2) AS p_FIP,
+        ROUND(
+            pi.p_IPouts / (
+                SELECT SUM(p.p_IPouts)
+                FROM pitching p
+                WHERE p.teamID = pi.teamID AND p.yearID = pi.yearID
+            ) * 100
+        , 3) AS p_playing_time
     FROM pitching pi
     JOIN people pe ON pe.playerID = pi.playerID
     JOIN lgavgview l ON pi.yearID = l.yearID

--- a/dbSetup/services/create_pitchingstats_view.py
+++ b/dbSetup/services/create_pitchingstats_view.py
@@ -134,7 +134,7 @@ def create_pitchingstats_view():
                 FROM pitching p
                 WHERE p.teamID = pi.teamID AND p.yearID = pi.yearID
             ) * 100
-        , 3) AS p_playing_time
+        , 0) AS p_playing_time
     FROM pitching pi
     JOIN people pe ON pe.playerID = pi.playerID
     JOIN lgavgview l ON pi.yearID = l.yearID


### PR DESCRIPTION
# Overview
This pull request includes changes to the `PitchingStatsView` class and the `create_pitchingstats_view` function to add a new statistic for playing time and to clean up the code by removing commented-out columns.

## Changes

Enhancements to pitching statistics:

* [`dbSetup/models/views/__init__.py`](diffhunk://#diff-b2618f086e86d38d1327063c4a254a8850bfd8eaa146cb93a5926878496b9750L75-R76): Added a new column `playing_time` to the `PitchingStatsView` class to track the playing time of pitchers.
* [`dbSetup/services/create_pitchingstats_view.py`](diffhunk://#diff-12e63bd998023731b1650f65b4e899092d2c7d323c24e6cf2ef9daaf4771847cL130-R137): Modified the `create_pitchingstats_view` function to calculate and include the `p_playing_time` statistic, which represents the percentage of playing time for each pitcher.

Code cleanup:

* [`dbSetup/models/views/__init__.py`](diffhunk://#diff-b2618f086e86d38d1327063c4a254a8850bfd8eaa146cb93a5926878496b9750L75-R76): Removed several commented-out columns (`p_GB_percent`, `p_HR_div_FB`, `p_XFIP`, `p_WAR`) from the `PitchingStatsView` class to clean up the code.

## Proof of Life
![playingtime-pol](https://github.com/user-attachments/assets/607c8ddb-c689-42c0-8c7a-a60a3f4219e4)

